### PR TITLE
Potential fix for code scanning alert no. 27: Insecure TLS configuration

### DIFF
--- a/server/tls.go
+++ b/server/tls.go
@@ -38,15 +38,15 @@ func parseProtocols(protoStr string) (minVersion, maxVersion uint16) {
 func buildCipherMap() {
 	cipherSuiteMap = make(map[string]uint16)
 
-	// 获取所有安全套件
+	// 仅获取安全套件
 	for _, suite := range tls.CipherSuites() {
 		cipherSuiteMap[suite.Name] = suite.ID
 	}
 
-	// 获取所有不安全套件
-	for _, suite := range tls.InsecureCipherSuites() {
-		cipherSuiteMap[suite.Name] = suite.ID
-	}
+	// 不再添加不安全套件
+	// 提示：代码已移除 InsecureCipherSuites 防止不安全套件被应用。
+	// 可以在 parseCipherSuites 的警告中说明不安全请求被忽略。
+
 	// 确保 TLS 1.3 套件在旧版本 Go 中可用
 	cipherSuiteMap["TLS_AES_128_GCM_SHA256"] = tls.TLS_AES_128_GCM_SHA256
 	cipherSuiteMap["TLS_AES_256_GCM_SHA384"] = tls.TLS_AES_256_GCM_SHA384


### PR DESCRIPTION
Potential fix for [https://github.com/qist/tvgate/security/code-scanning/27](https://github.com/qist/tvgate/security/code-scanning/27)

The correct fix is to ensure that only secure cipher suites are allowed in user configuration or at runtime. This means:

1. Filter out any cipher suite IDs from `tls.InsecureCipherSuites()` in the cipher suite mapping or before building the slice passed to `tls.Config.CipherSuites`.
2. When parsing user-supplied cipher names (`parseCipherSuites`), map only to secure cipher suites.
3. When building the cipher suite map, exclude entries from `tls.InsecureCipherSuites()`, and optionally log/reject them if attempted.
4. Update the `buildCipherMap` function to only include suites from `tls.CipherSuites()`, not `tls.InsecureCipherSuites()`.
5. Optionally, add additional runtime warnings/rejection in `parseCipherSuites` if an insecure cipher is explicitly requested by name.

Changes are needed **only in `server/tls.go`**:
- Remove the loop adding insecure suites in `buildCipherMap`.
- Optionally, add logging so that users are warned if they request a deprecated cipher suite.

No functional changes will occur to existing valid configs, but insecure configs will be correctly rejected or ignored.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
