### PR TITLE
Potential fix for code scanning alert no. 17: Disabled TLS certificate check

### DIFF
--- a/proxy/client.go
+++ b/proxy/client.go
@@ -24,7 +24,7 @@ func CreateProxyClient(ctx context.Context, cfg *config.Config, proxyConfig conf
 	proxyAddr := fmt.Sprintf("%s:%d", proxyConfig.Server, proxyConfig.Port)
 
 	transport := &http.Transport{
-		TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: false},
 		ResponseHeaderTimeout: 10 * time.Second,
 		IdleConnTimeout:       5 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,


### PR DESCRIPTION
Potential fix for [https://github.com/qist/tvgate/security/code-scanning/17](https://github.com/qist/tvgate/security/code-scanning/17)

To safely fix the problem, you should never set `InsecureSkipVerify: true` in production code unless absolutely necessary, and if so, only allow this via a dedicated configuration option for testing and debugging purposes, never by default. The fix is to set `InsecureSkipVerify: false`, which ensures the HTTP client verifies TLS certificates, protecting against man-in-the-middle attacks.

You should edit line 27 of `proxy/client.go`, changing `InsecureSkipVerify: true` to `InsecureSkipVerify: false`. No other changes are needed unless you want to add conditional logic for very specialized use cases, which is not recommended by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
