### PR TITLE
Potential fix for code scanning alert no. 20: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/updater/github_updater.go
+++ b/updater/github_updater.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -269,15 +270,28 @@ func unzip(src, dest string) error {
 	}
 	defer r.Close()
 
+	absDest, err := filepath.Abs(dest)
+	if err != nil {
+		return err
+	}
+
 	for _, f := range r.File {
+		// Prevent Zip Slip by checking for path traversal in f.Name
 		path := filepath.Join(dest, f.Name)
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			continue // skip on error resolving path
+		}
+		if !strings.HasPrefix(absPath, absDest+string(os.PathSeparator)) && absPath != absDest {
+			continue // skip extracting this entry
+		}
 		if f.FileInfo().IsDir() {
-			_ = os.MkdirAll(path, f.Mode())
+			_ = os.MkdirAll(absPath, f.Mode())
 			continue
 		}
-		_ = os.MkdirAll(filepath.Dir(path), 0755)
+		_ = os.MkdirAll(filepath.Dir(absPath), 0755)
 		rc, _ := f.Open()
-		out, _ := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
+		out, _ := os.OpenFile(absPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, f.Mode())
 		_, _ = io.Copy(out, rc)
 		rc.Close()
 		out.Close()


### PR DESCRIPTION
Potential fix for [https://github.com/qist/tvgate/security/code-scanning/20](https://github.com/qist/tvgate/security/code-scanning/20)

To fix the Zip Slip vulnerability, we must ensure that the files and directories extracted from the zip archive do not escape the designated output directory (the value of `dest`). The safest and simplest way to do this is:
- For each archive entry `f.Name`, after joining it with `dest` to form the intended path, we will obtain the absolute path of this intended extraction.
- We then verify that this absolute path is indeed within (or is a child of) the absolute path of `dest`, rejecting (and skipping) any entry whose path escapes the output directory (i.e., contains `..` components or absolute or symlink-influenced paths).
- To implement this fix, within `unzip`, after constructing `path := filepath.Join(dest, f.Name)`, obtain the absolute path for both `path` and `dest`, and check that `absPath` is prefixed by `absDest` (with proper path separators).
- If the check fails, skip extraction of that entry (possibly logging or counting skipped entries).

Required edits:
- Add necessary imports (`strings` if not already imported).
- In `unzip`, before filesystem operations in the loop, resolve and check path safety.

All changes are in updater/github_updater.go, in function `unzip`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
