### PR TITLE
Potential fix for code scanning alert no. 16: Disabled TLS certificate check

### DIFF
--- a/domainmap/handler.go
+++ b/domainmap/handler.go
@@ -886,7 +886,7 @@ func (dm *DomainMapper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		MaxIdleConnsPerHost:   httpCfg.MaxIdleConnsPerHost,
 		MaxConnsPerHost:       httpCfg.MaxConnsPerHost,
 		DisableKeepAlives:     httpCfg.DisableKeepAlives,
-		TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig:       &tls.Config{InsecureSkipVerify: false},
 	}
 
 	// 创建 Client


### PR DESCRIPTION
Potential fix for [https://github.com/qist/tvgate/security/code-scanning/16](https://github.com/qist/tvgate/security/code-scanning/16)

To address the problem, `InsecureSkipVerify` should not be set to `true` for production code. Instead, set it to `false` (the default), or leave it unset, which will enable certificate and hostname verification. If there's a need to customize trusted certificate authorities, supply a proper `RootCAs` or other options in the `tls.Config`. In the snippet, simply remove `InsecureSkipVerify: true` or set it to `false` on line 889. The most direct fix is to change:

```go
TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
```
to

```go
TLSClientConfig: &tls.Config{},
```
or

```go
TLSClientConfig: &tls.Config{InsecureSkipVerify: false},
```

The rest of the code does not need to change unless custom certificate validation must be configured, which is not shown in the provided snippet.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
